### PR TITLE
Add JSON-LD fallback for Meetup events, update sync script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ bundle exec jekyll serve
 The homepage reads event data from `_data/events.json`.
 
 - **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours and on manual dispatch.
-- **Sync script:** `scripts/sync_meetup_events.py` fetches Meetup iCal data and writes deterministic JSON output.
+- **Sync script:** `scripts/sync_meetup_events.py` fetches Meetup data and writes deterministic JSON output.
+  - Primary source: Meetup iCal feed.
+  - Fallback source: JSON-LD event data from the Meetup events page.
 - **Commit behavior:** The workflow only commits when `_data/events.json` actually changes.
 - **Failure behavior:** If Meetup fetch fails, the script logs a warning and keeps the last successful local data file.
 
@@ -22,6 +24,8 @@ The homepage reads event data from `_data/events.json`.
 
 - `MEETUP_ICAL_URL` (optional): override iCal endpoint used by the sync job.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/ical/`.
+- `MEETUP_EVENTS_URL` (optional): override Meetup events page URL used as the JSON-LD fallback source.
+  - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/`.
 
 ### Manual sync
 

--- a/_data/events.json
+++ b/_data/events.json
@@ -1,35 +1,46 @@
 [
   {
-    "title": "Info session: GenAI Gurus Project Incubator with Microsoft for Startups Founders Hub",
-    "date": "2024-04-21T15:30:00Z",
-    "event_status": "past",
-    "speaker_name": "GenAI Gurus Team",
-    "location_label": "Online",
-    "meetup_url": "https://www.meetup.com/genai-gurus/",
-    "youtube_url": "",
-    "image": "/images/Incubator.png",
-    "summary": "An info session for AI builders on project incubation, startup support, and practical next steps."
-  },
-  {
-    "title": "Community call",
-    "date": "2024-01-22T16:30:00Z",
+    "title": "GenAI Gurus community call",
+    "date": "2025-10-20T16:30:00Z",
     "event_status": "past",
     "speaker_name": "GenAI Gurus Community",
     "location_label": "Online",
-    "meetup_url": "https://www.meetup.com/genai-gurus/",
+    "meetup_url": "https://www.meetup.com/genai-gurus/events/307464559/",
     "youtube_url": "",
     "image": "/images/cc.png",
-    "summary": "A community discussion on current GenAI trends, member updates, and upcoming collaboration topics."
+    "summary": "Monthly community call to connect GenAI enthusiasts, share updates, and discuss upcoming expert talks."
   },
   {
-    "title": "Symphony of the Future: Azure AI and OpenAI collaboration",
-    "date": "2023-11-16T17:30:00Z",
+    "title": "GenAI Gurus community call",
+    "date": "2025-09-15T16:30:00Z",
     "event_status": "past",
-    "speaker_name": "GenAI Gurus Guests",
+    "speaker_name": "GenAI Gurus Community",
     "location_label": "Online",
-    "meetup_url": "https://www.meetup.com/genai-gurus/",
+    "meetup_url": "https://www.meetup.com/genai-gurus/events/307202482/",
     "youtube_url": "",
-    "image": "/images/et-as.png",
-    "summary": "An expert talk on Azure AI and OpenAI collaboration patterns for enterprise and product teams."
+    "image": "/images/cc.png",
+    "summary": "Monthly community call to connect GenAI enthusiasts, share updates, and discuss upcoming expert talks."
+  },
+  {
+    "title": "GenAI Gurus community call",
+    "date": "2025-08-18T16:30:00Z",
+    "event_status": "past",
+    "speaker_name": "GenAI Gurus Community",
+    "location_label": "Online",
+    "meetup_url": "https://www.meetup.com/genai-gurus/events/307047644/",
+    "youtube_url": "",
+    "image": "/images/cc.png",
+    "summary": "Monthly community call to connect GenAI enthusiasts, share updates, and discuss upcoming expert talks."
+  },
+  {
+    "title": "GenAI Gurus community call",
+    "date": "2025-07-21T16:30:00Z",
+    "event_status": "past",
+    "speaker_name": "GenAI Gurus Community",
+    "location_label": "Online",
+    "meetup_url": "https://www.meetup.com/genai-gurus/events/306030348/",
+    "youtube_url": "",
+    "image": "/images/cc.png",
+    "summary": "Monthly community call to connect GenAI enthusiasts, share updates, and discuss upcoming expert talks."
   }
 ]

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
           </article>
         {% else %}
           <article class="event-card event-card--featured">
-            <h3>No upcoming event is listed yet.</h3>
+            <h3>No upcoming event is currently listed on Meetup.</h3>
             <p>See the latest announcements and RSVP to new sessions on Meetup.</p>
             <a class="button button--primary" href="{{ site.data.settings.meetup }}" target="_blank" rel="noopener noreferrer">View Meetup events</a>
           </article>

--- a/scripts/sync_meetup_events.py
+++ b/scripts/sync_meetup_events.py
@@ -16,6 +16,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_FILE = REPO_ROOT / "_data" / "events.json"
 DEFAULT_ICAL_URL = "https://www.meetup.com/genai-gurus/events/ical/"
+DEFAULT_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/"
 
 
 def log(msg: str) -> None:
@@ -117,15 +118,124 @@ def parse_ical_events(ical_text: str) -> list[dict[str, str]]:
     return parsed_events
 
 
+def to_utc_iso(value: str) -> str | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    normalized = raw.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
+    script_pattern = re.compile(
+        r'<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    now = dt.datetime.now(dt.timezone.utc)
+    parsed_events: list[dict[str, str]] = []
+
+    for match in script_pattern.findall(events_html):
+        candidate = match.strip()
+        if not candidate:
+            continue
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+
+        nodes = payload if isinstance(payload, list) else [payload]
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            node_type = node.get("@type")
+            if isinstance(node_type, list):
+                is_event = "Event" in node_type
+            else:
+                is_event = node_type == "Event"
+            if not is_event:
+                continue
+
+            date_iso = to_utc_iso(str(node.get("startDate", "")))
+            if not date_iso:
+                continue
+
+            event_dt = dt.datetime.fromisoformat(date_iso.replace("Z", "+00:00"))
+            location = node.get("location", {})
+            if isinstance(location, dict):
+                location_name = str(location.get("name", "")).strip()
+            else:
+                location_name = ""
+            description = strip_html(str(node.get("description", "")))
+            speaker = ""
+            performer = node.get("performer")
+            if isinstance(performer, dict):
+                speaker = str(performer.get("name", "")).strip()
+            elif isinstance(performer, list):
+                names = [str(p.get("name", "")).strip() for p in performer if isinstance(p, dict)]
+                speaker = ", ".join([n for n in names if n])
+
+            parsed_events.append(
+                {
+                    "title": strip_html(str(node.get("name", ""))) or "GenAI Gurus Event",
+                    "date": date_iso,
+                    "event_status": "upcoming" if event_dt >= now else "past",
+                    "speaker_name": speaker or extract_speaker("", description),
+                    "location_label": location_name or "Online",
+                    "meetup_url": str(node.get("url", "")).strip() or DEFAULT_EVENTS_URL,
+                    "youtube_url": "",
+                    "image": "",
+                    "summary": description[:280],
+                }
+            )
+
+    deduped: dict[str, dict[str, str]] = {}
+    for event in parsed_events:
+        key = event.get("meetup_url") or f"{event.get('title')}|{event.get('date')}"
+        deduped[key] = event
+    ordered = sorted(deduped.values(), key=lambda e: e["date"])
+    return ordered
+
+
 def fetch_events() -> list[dict[str, str]]:
     source_url = os.environ.get("MEETUP_ICAL_URL", DEFAULT_ICAL_URL)
+    events_url = os.environ.get("MEETUP_EVENTS_URL", DEFAULT_EVENTS_URL)
     headers = {"User-Agent": "genai-gurus-event-sync/1.0"}
-    req = urllib.request.Request(source_url, headers=headers)
-    with urllib.request.urlopen(req, timeout=25) as response:
-        if response.status != 200:
-            raise RuntimeError(f"Meetup fetch failed with status {response.status}")
-        payload = response.read().decode("utf-8", errors="replace")
-    return parse_ical_events(payload)
+
+    errors: list[str] = []
+
+    try:
+        req = urllib.request.Request(source_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=25) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Meetup iCal fetch failed with status {response.status}")
+            payload = response.read().decode("utf-8", errors="replace")
+        events = parse_ical_events(payload)
+        if events:
+            return events
+        errors.append("Meetup iCal response contained no events")
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        errors.append(f"iCal source failed: {exc}")
+
+    try:
+        req = urllib.request.Request(events_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=25) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Meetup events page fetch failed with status {response.status}")
+            payload = response.read().decode("utf-8", errors="replace")
+        events = parse_ld_json_events(payload)
+        if events:
+            return events
+        errors.append("Meetup events page contained no parseable JSON-LD events")
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        errors.append(f"events page source failed: {exc}")
+
+    raise RuntimeError("; ".join(errors))
 
 
 def write_if_changed(events: list[dict[str, str]]) -> bool:


### PR DESCRIPTION
### Motivation
- Improve resilience of the meetup sync by falling back to JSON-LD embedded on the Meetup events page when the iCal feed is missing or empty.
- Clarify README and expose an optional env var for overriding the Meetup events page URL.
- Refresh sample event data and tweak homepage copy to indicate Meetup is the authoritative source for upcoming events.

### Description
- Added `DEFAULT_EVENTS_URL` and support for `MEETUP_EVENTS_URL` to the sync script and README.
- Implemented `parse_ld_json_events` and helper `to_utc_iso` to extract Event nodes from `application/ld+json` scripts on the Meetup events page and normalize timestamps to UTC ISO format.
- Modified `fetch_events` to attempt the iCal source first and then fall back to parsing the events page HTML if iCal fails or contains no events, and to aggregate parse errors into a single `RuntimeError` when both sources fail.
- Updated `README.md` to document the fallback source and updated `_data/events.json` and `index.html` copy to reflect refreshed event details and messaging.

### Testing
- No automated tests were added or modified for this change.
- Existing CI configuration was not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8e1135cc83249c0effb5698e444e)