### PR TITLE
Ensure at least four recent past events are shown

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,10 +91,22 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
           </div>
         {% endif %}
       {% endfor %}
-      {% if past_count == 0 %}
-        <div class="col col-12">
-          <p>No past events are available yet.</p>
-        </div>
+      {% assign fallback_needed = 4 | minus: past_count %}
+      {% if fallback_needed > 0 %}
+        {% for post in site.posts limit:fallback_needed %}
+          {% assign past_count = past_count | plus: 1 %}
+          <div class="col col-4 col-d-6 col-t-12">
+            <article class="event-card">
+              <p class="event-card__meta">{{ post.date | date: "%b %-d, %Y" }}</p>
+              <h3>{{ post.title }}</h3>
+              <p class="event-card__speaker">Community archive</p>
+              {% if post.excerpt %}<p>{{ post.excerpt | strip_html | strip_newlines | truncate: 180 }}</p>{% endif %}
+              <div class="event-card__links">
+                <a href="{{ post.url | relative_url }}">Details</a>
+              </div>
+            </article>
+          </div>
+        {% endfor %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
### Motivation

- The events feed can sometimes contain only upcoming items which leaves the "Recent past events" section empty or sparse. 
- Visitors should always see at least the last four historical items to provide continuity and context.

### Description

- Updated the homepage `Recent past events` block in `index.html` to keep rendering Meetup-derived past events first and then backfill from site archives when needed. 
- Added a fallback that computes `fallback_needed = 4 | minus: past_count` and renders up to that many `site.posts` as event cards showing `post.date`, `post.title`, a `Community archive` speaker label, a truncated `post.excerpt`, and a `Details` link. 
- Removed the previous "No past events are available yet." message and replaced it with the archive backfill so the section always shows content when posts exist.

### Testing

- Ran the sync script with `python scripts/sync_meetup_events.py`, which logged network fetch failures and left the existing `_data/events.json` in place. 
- Inspected `_data/events.json` after the run and observed `count 1`, `past 0`, and `upcoming 1`, confirming there are no Meetup past events to render locally. 
- Attempted `bundle exec jekyll build` to render the site, but `jekyll` was not available and `bundle install` failed due to `rubygems.org` returning `403 Forbidden`, so a full build of the site could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00a3c0cf483248a8402bd1b769c55)