### PR TITLE
Enhance next event card with featured image

### DIFF
--- a/_sass/4-layouts/_page-home.scss
+++ b/_sass/4-layouts/_page-home.scss
@@ -72,6 +72,22 @@
   padding: 28px;
 }
 
+
+.event-card__featured-media {
+  margin: -28px -28px 18px;
+  border-radius: 8px 8px 0 0;
+  overflow: hidden;
+  background: $light-gray;
+
+  img {
+    display: block;
+    width: 100%;
+    max-height: 320px;
+    object-fit: cover;
+    aspect-ratio: 16 / 9;
+  }
+}
+
 .event-card__meta {
   margin-bottom: 8px;
   font-size: 13px;

--- a/index.html
+++ b/index.html
@@ -39,7 +39,11 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
       </div>
       <div class="col col-12">
         {% if next_event %}
+          {% assign next_event_image = next_event.image | default: site.data.settings.default_image %}
           <article class="event-card event-card--featured">
+            <div class="event-card__featured-media">
+              <img src="{{ next_event_image }}" alt="{{ next_event.title }} event image" loading="lazy" />
+            </div>
             <p class="event-card__meta">{{ next_event.date | date: "%A, %B %-d, %Y at %-I:%M %p %Z" }}{% if next_event.location_label %} · {{ next_event.location_label }}{% endif %}</p>
             <h3>{{ next_event.title }}</h3>
             {% if next_event.speaker_name %}<p class="event-card__speaker">Speaker: {{ next_event.speaker_name }}</p>{% endif %}
@@ -47,7 +51,11 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
             <a class="button button--primary" href="{{ next_event.meetup_url }}" target="_blank" rel="noopener noreferrer">Register on Meetup</a>
           </article>
         {% elsif latest_event %}
+          {% assign latest_event_image = latest_event.image | default: site.data.settings.default_image %}
           <article class="event-card event-card--featured">
+            <div class="event-card__featured-media">
+              <img src="{{ latest_event_image }}" alt="{{ latest_event.title }} event image" loading="lazy" />
+            </div>
             <p class="event-card__meta">{{ latest_event.date | date: "%A, %B %-d, %Y at %-I:%M %p %Z" }}{% if latest_event.location_label %} · {{ latest_event.location_label }}{% endif %}</p>
             <h3>{{ latest_event.title }}</h3>
             <p class="event-card__speaker">No upcoming Meetup event is listed right now — showing the latest session.</p>


### PR DESCRIPTION
### Motivation
- The homepage "Next event" card did not include an event picture, making the section visually sparse and inconsistent with event listings. 
- Ensure the next-event area always shows a visual by using the event `image` when available and falling back to a site default image. 

### Description
- Updated `index.html` to render a featured image block for the `next_event` and the `latest_event` fallback, using `next_event.image | default: site.data.settings.default_image` (and equivalent for `latest_event`) and `loading="lazy"` with descriptive `alt` text. 
- Added `.event-card__featured-media` to `_sass/4-layouts/_page-home.scss` to style the header image (full-width, rounded top corners, clipped overflow, `object-fit: cover`, 16:9 aspect ratio and a capped `max-height`). 
- Kept existing metadata, speaker and CTA markup intact so behavior for registration and fallback links is unchanged. 

### Testing
- Ran `git diff --check` which reported no issues. 
- Attempted `bundle exec jekyll build --quiet` which could not run because the `jekyll` executable is not available in this environment. 
- Attempted `bundle install` which failed due to `403 Forbidden` errors when fetching gems from `rubygems.org` in this environment, so a local site build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00a64337883248ea9dcfae7b73d03)