### PR TITLE
Add cover images and post fallbacks for recent past events on homepage

### DIFF
--- a/_sass/4-layouts/_page-home.scss
+++ b/_sass/4-layouts/_page-home.scss
@@ -79,6 +79,15 @@
   color: $brand-color;
 }
 
+.event-card__image {
+  display: block;
+  width: 100%;
+  height: 180px;
+  margin-bottom: 14px;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
 .event-card__speaker {
   margin-bottom: 10px;
   font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -79,6 +79,8 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
           {% assign past_count = past_count | plus: 1 %}
           <div class="col col-4 col-d-6 col-t-12">
             <article class="event-card">
+              {% assign event_image = event.image | default: "images/logo1.png" %}
+              <img class="event-card__image" src="{{ event_image | relative_url }}" alt="{{ event.title }} cover image" loading="lazy">
               <p class="event-card__meta">{{ event.date | date: "%b %-d, %Y" }}</p>
               <h3>{{ event.title }}</h3>
               {% if event.speaker_name %}<p class="event-card__speaker">{{ event.speaker_name }}</p>{% endif %}
@@ -91,10 +93,24 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
           </div>
         {% endif %}
       {% endfor %}
-      {% if past_count == 0 %}
-        <div class="col col-12">
-          <p>No past events are available yet.</p>
-        </div>
+      {% assign fallback_needed = 4 | minus: past_count %}
+      {% if fallback_needed > 0 %}
+        {% for post in site.posts limit:fallback_needed %}
+          {% assign past_count = past_count | plus: 1 %}
+          <div class="col col-4 col-d-6 col-t-12">
+            <article class="event-card">
+              {% assign post_image = post.image | default: "images/logo1.png" %}
+              <img class="event-card__image" src="{{ post_image | relative_url }}" alt="{{ post.title }} cover image" loading="lazy">
+              <p class="event-card__meta">{{ post.date | date: "%b %-d, %Y" }}</p>
+              <h3>{{ post.title }}</h3>
+              <p class="event-card__speaker">Community archive</p>
+              {% if post.excerpt %}<p>{{ post.excerpt | strip_html | strip_newlines | truncate: 180 }}</p>{% endif %}
+              <div class="event-card__links">
+                <a href="{{ post.url | relative_url }}">Details</a>
+              </div>
+            </article>
+          </div>
+        {% endfor %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
### Motivation

- Improve the appearance and consistency of past event cards by adding support for cover images and a visual card layout, and ensure the events grid is populated when there are few past events by falling back to recent posts.

### Description

- Add `.event-card__image` styles in `_sass/4-layouts/_page-home.scss` to size, round, and `object-fit: cover` event/post images.
- Insert image markup into the past events loop in `index.html`, defaulting to `images/logo1.png`, with `alt` text and `loading="lazy"` attributes.
- Add a fallback loop that fills remaining slots (up to 4 total) from `site.posts`, rendering post image, date, truncated excerpt, and a details link when there are not enough past events.
- Ensure fallback cards show a speaker/credit line (`Community archive`) and reuse the `.event-card` layout and links structure.

### Testing

- Ran `jekyll build` and the site built successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00a3c0cf483248a8402bd1b769c55)