### PR TITLE
Add event images, expand past events, and add Meetup footer link on homepage

### DIFF
--- a/_sass/4-layouts/_page-home.scss
+++ b/_sass/4-layouts/_page-home.scss
@@ -79,6 +79,15 @@
   color: $brand-color;
 }
 
+.event-card__image {
+  display: block;
+  width: 100%;
+  height: 180px;
+  margin-bottom: 14px;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
 .event-card__speaker {
   margin-bottom: 10px;
   font-weight: 700;
@@ -92,6 +101,10 @@
     margin-right: 16px;
     font-weight: 700;
   }
+}
+
+.events-section__footer {
+  margin-top: 14px;
 }
 
 .contact-inline {

--- a/index.html
+++ b/index.html
@@ -75,10 +75,12 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
       {% assign past_count = 0 %}
       {% for event in events reversed %}
         {% assign event_ts = event.date | date: '%s' %}
-        {% if event_ts < now_ts and past_count < 6 %}
+        {% if event_ts < now_ts and past_count < 9 %}
           {% assign past_count = past_count | plus: 1 %}
           <div class="col col-4 col-d-6 col-t-12">
             <article class="event-card">
+              {% assign event_image = event.image | default: "images/logo1.png" %}
+              <img class="event-card__image" src="{{ event_image | relative_url }}" alt="{{ event.title }} cover image" loading="lazy">
               <p class="event-card__meta">{{ event.date | date: "%b %-d, %Y" }}</p>
               <h3>{{ event.title }}</h3>
               {% if event.speaker_name %}<p class="event-card__speaker">{{ event.speaker_name }}</p>{% endif %}
@@ -93,7 +95,12 @@ description: GenAI Gurus is a community exploring practical, technical, and soci
       {% endfor %}
       {% if past_count == 0 %}
         <div class="col col-12">
-          <p>No past events are available yet.</p>
+          <p>No past Meetup events are available yet.</p>
+        </div>
+      {% endif %}
+      {% if past_count > 0 %}
+        <div class="col col-12 events-section__footer">
+          <a class="button" href="https://www.meetup.com/genai-gurus/events/past/" target="_blank" rel="noopener noreferrer">See all past events on Meetup</a>
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
### Motivation
- Improve the events listing on the homepage by surfacing event cover images and making it easier to browse past Meetup sessions.
- Provide a clearer call-to-action to view all past events on Meetup and adjust how many past events are shown.

### Description
- Increased the number of displayed past events from 6 to 9 by changing the `past_count` limit in `index.html`.
- Added an event cover image element with a default fallback and lazy loading in `index.html` using `event.image` and an `img.event-card__image` element with `alt` and `loading="lazy"` attributes.
- Introduced styles for `.event-card__image` and `.events-section__footer` in `_sass/4-layouts/_page-home.scss` to size images with `object-fit: cover` and to space the footer link.
- Added a footer button linking to the Meetup past events page and clarified the "no past events" message text in the events section of `index.html`.

### Testing
- Performed a local site build with `jekyll build` and the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00a3c0cf483248a8402bd1b769c55)