### PR TITLE
ci: trigger Meetup sync on PRs and all pushes to main

### DIFF
--- a/.github/workflows/sync-meetup-events.yml
+++ b/.github/workflows/sync-meetup-events.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
       - master
-    paths:
-      - '.github/workflows/sync-meetup-events.yml'
-      - 'scripts/sync_meetup_events.py'
-      - '_data/events.json'
+  pull_request:
+    branches:
+      - main
+      - master
   schedule:
     - cron: '15 */12 * * *'
   workflow_dispatch:
@@ -54,6 +54,7 @@ jobs:
           PY
 
       - name: Commit changes when event data changed
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           if git diff --quiet -- _data/events.json; then
             echo "No changes to commit"


### PR DESCRIPTION
### Motivation
- Ensure the `Sync Meetup events` workflow runs after every pull request targeting `main`/`master` and on all pushes to those branches because the previous `push.paths` filter prevented runs after most PRs. 
- Avoid attempts to push changes back from runs triggered by PRs by skipping the commit step for `pull_request` events.

### Description
- Added a `pull_request` trigger for `main`/`master` and removed the `push.paths` filter so the workflow runs on all pushes to those branches and on PRs targeting them in `sync-meetup-events.yml`.
- Guarded the commit step with `if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` so commits/pushes only occur on non-PR runs.
- Left the sync logic in `scripts/sync_meetup_events.py` and the event output `_data/events.json` handling unchanged.

### Testing
- Reviewed the workflow diff and verified the updated triggers and the commit-step conditional in `sync-meetup-events.yml`.
- Attempted to parse the workflow YAML using Python `PyYAML`, but parsing failed because `PyYAML` is not installed in the environment.
- Confirmed the updated workflow file is present in the repository and reflects the intended changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00cf23d248324b27b8d29fdbb43cb)