### PR TITLE
Support past Meetup events and iCal unescaping; run sync on PRs and refine commit condition

### DIFF
--- a/.github/workflows/sync-meetup-events.yml
+++ b/.github/workflows/sync-meetup-events.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
       - master
-    paths:
-      - '.github/workflows/sync-meetup-events.yml'
-      - 'scripts/sync_meetup_events.py'
-      - '_data/events.json'
+  pull_request:
+    branches:
+      - main
+      - master
   schedule:
     - cron: '15 */12 * * *'
   workflow_dispatch:
@@ -54,6 +54,7 @@ jobs:
           PY
 
       - name: Commit changes when event data changed
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           if git diff --quiet -- _data/events.json; then
             echo "No changes to commit"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ bundle exec jekyll serve
 
 The homepage reads event data from `_data/events.json`.
 
-- **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours and on manual dispatch.
-  - It also runs on pushes to `main`/`master` that touch the workflow, sync script, or `_data/events.json` so first-time setup is easier to verify.
+- **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours, on manual dispatch, on pull requests targeting `main`/`master`, and on all pushes to `main`/`master`.
 - **Sync script:** `scripts/sync_meetup_events.py` fetches Meetup data and writes deterministic JSON output.
   - Primary source: Meetup iCal feed.
   - Fallback source: JSON-LD event data from the Meetup events page.
@@ -28,6 +27,8 @@ The homepage reads event data from `_data/events.json`.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/ical/`.
 - `MEETUP_EVENTS_URL` (optional): override Meetup events page URL used as the JSON-LD fallback source.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/`.
+- `MEETUP_PAST_EVENTS_URL` (optional): override Meetup past-events page URL used to supplement iCal with recent historical events.
+  - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/past/`.
 - `MEETUP_SYNC_STRICT` (optional): if truthy (`1`, `true`, `yes`, `on`), the script exits non-zero when fetch fails.
   - Useful in CI to surface data-source outages immediately.
 

--- a/scripts/sync_meetup_events.py
+++ b/scripts/sync_meetup_events.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_FILE = REPO_ROOT / "_data" / "events.json"
 DEFAULT_ICAL_URL = "https://www.meetup.com/genai-gurus/events/ical/"
 DEFAULT_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/"
+DEFAULT_PAST_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/past/"
 
 
 def log(msg: str) -> None:
@@ -53,6 +54,16 @@ def strip_html(value: str) -> str:
     no_tags = re.sub(r"<[^>]+>", " ", value)
     normalized = re.sub(r"\s+", " ", no_tags)
     return html.unescape(normalized).strip()
+
+
+def unescape_ical_text(value: str) -> str:
+    return (
+        value.replace("\\n", "\n")
+        .replace("\\N", "\n")
+        .replace("\\,", ",")
+        .replace("\\;", ";")
+        .replace("\\\\", "\\")
+    )
 
 
 def extract_speaker(summary: str, description: str) -> str:
@@ -94,9 +105,9 @@ def parse_ical_events(ical_text: str) -> list[dict[str, str]]:
         if event_dt is None:
             continue
 
-        summary = strip_html(item.get("SUMMARY", "")).strip()
-        description = strip_html(item.get("DESCRIPTION", "")).strip()
-        location = strip_html(item.get("LOCATION", "")).strip()
+        summary = strip_html(unescape_ical_text(item.get("SUMMARY", ""))).strip()
+        description = strip_html(unescape_ical_text(item.get("DESCRIPTION", ""))).strip()
+        location = strip_html(unescape_ical_text(item.get("LOCATION", ""))).strip()
         meetup_url = item.get("URL", "").strip() or DEFAULT_ICAL_URL
         speaker = extract_speaker(summary, description)
 
@@ -202,12 +213,25 @@ def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
     return ordered
 
 
+def merge_events(*event_lists: list[dict[str, str]]) -> list[dict[str, str]]:
+    merged: dict[str, dict[str, str]] = {}
+    for events in event_lists:
+        for event in events:
+            key = event.get("meetup_url") or f"{event.get('title')}|{event.get('date')}"
+            merged[key] = event
+    return sorted(merged.values(), key=lambda e: e["date"])
+
+
 def fetch_events() -> list[dict[str, str]]:
     source_url = getenv_or_default("MEETUP_ICAL_URL", DEFAULT_ICAL_URL)
     events_url = getenv_or_default("MEETUP_EVENTS_URL", DEFAULT_EVENTS_URL)
+    past_events_url = getenv_or_default("MEETUP_PAST_EVENTS_URL", DEFAULT_PAST_EVENTS_URL)
     headers = {"User-Agent": "genai-gurus-event-sync/1.0"}
 
     errors: list[str] = []
+
+    ical_events: list[dict[str, str]] = []
+    past_events: list[dict[str, str]] = []
 
     try:
         req = urllib.request.Request(source_url, headers=headers)
@@ -215,12 +239,29 @@ def fetch_events() -> list[dict[str, str]]:
             if response.status != 200:
                 raise RuntimeError(f"Meetup iCal fetch failed with status {response.status}")
             payload = response.read().decode("utf-8", errors="replace")
-        events = parse_ical_events(payload)
-        if events:
-            return events
-        errors.append("Meetup iCal response contained no events")
+        ical_events = parse_ical_events(payload)
+        if ical_events:
+            log(f"Fetched {len(ical_events)} events from iCal")
+        else:
+            errors.append("Meetup iCal response contained no events")
     except (urllib.error.URLError, RuntimeError, ValueError) as exc:
         errors.append(f"iCal source failed: {exc}")
+
+    try:
+        req = urllib.request.Request(past_events_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=25) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Meetup past events page fetch failed with status {response.status}")
+            payload = response.read().decode("utf-8", errors="replace")
+        past_events = [event for event in parse_ld_json_events(payload) if event.get("event_status") == "past"]
+        if past_events:
+            log(f"Fetched {len(past_events)} past events from events/past page")
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        errors.append(f"past events source failed: {exc}")
+
+    merged_events = merge_events(ical_events, past_events)
+    if merged_events:
+        return merged_events
 
     try:
         req = urllib.request.Request(events_url, headers=headers)


### PR DESCRIPTION
### Motivation

- Include recent historical events not present in the iCal feed by pulling the Meetup `events/past/` page and merging results to ensure the site shows recent past events. 
- Properly unescape iCal-encoded text (line breaks, escaped commas/semicolons/backslashes) so event titles, descriptions, and locations render correctly. 
- Make the GitHub Actions workflow run on pull requests for easier review while preventing those runs from attempting to commit changes back to the repo.

### Description

- Updated the workflow `.github/workflows/sync-meetup-events.yml` to add a `pull_request` trigger for `main`/`master` and changed the commit step conditional to only commit on `push`, `schedule`, or `workflow_dispatch`. 
- Documented the new triggers and a new optional `MEETUP_PAST_EVENTS_URL` override in `README.md`. 
- In `scripts/sync_meetup_events.py` added `DEFAULT_PAST_EVENTS_URL`, implemented `unescape_ical_text` and applied it to `SUMMARY`, `DESCRIPTION`, and `LOCATION` fields so iCal escapes are decoded. 
- Added `merge_events` and enhanced `fetch_events` to fetch iCal events and the `events/past` page, merge/dedupe them (preferring `meetup_url` keys), log counts, and fall back to the main events page only if necessary.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00cf23d248324b27b8d29fdbb43cb)