### PR TITLE
Sync: crawl past Meetup events, improve parsing and debug, and expand workflow triggers

### DIFF
--- a/.github/workflows/sync-meetup-events.yml
+++ b/.github/workflows/sync-meetup-events.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
       - master
-    paths:
-      - '.github/workflows/sync-meetup-events.yml'
-      - 'scripts/sync_meetup_events.py'
-      - '_data/events.json'
+  pull_request:
+    branches:
+      - main
+      - master
   schedule:
     - cron: '15 */12 * * *'
   workflow_dispatch:
@@ -33,6 +33,7 @@ jobs:
         run: python scripts/sync_meetup_events.py
         env:
           MEETUP_SYNC_STRICT: '1'
+          MEETUP_SYNC_DEBUG: '1'
 
       - name: Show synced event stats
         run: |
@@ -51,9 +52,17 @@ jobs:
             print("Next upcoming:")
             next_event = sorted(upcoming, key=lambda e: e.get("date", ""))[0]
             print(f"- {next_event.get('date')} | {next_event.get('title')}")
+          if past:
+            print("Most recent past:")
+            most_recent_past = sorted(past, key=lambda e: e.get("date", ""), reverse=True)[0]
+            print(f"- {most_recent_past.get('date')} | {most_recent_past.get('title')}")
+            print(f"- URL: {most_recent_past.get('meetup_url')}")
+          else:
+            print("Most recent past: <none>")
           PY
 
       - name: Commit changes when event data changed
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           if git diff --quiet -- _data/events.json; then
             echo "No changes to commit"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ bundle exec jekyll serve
 
 The homepage reads event data from `_data/events.json`.
 
-- **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours and on manual dispatch.
-  - It also runs on pushes to `main`/`master` that touch the workflow, sync script, or `_data/events.json` so first-time setup is easier to verify.
+- **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours, on manual dispatch, on pull requests targeting `main`/`master`, and on all pushes to `main`/`master`.
 - **Sync script:** `scripts/sync_meetup_events.py` fetches Meetup data and writes deterministic JSON output.
   - Primary source: Meetup iCal feed.
   - Fallback source: JSON-LD event data from the Meetup events page.
@@ -28,8 +27,11 @@ The homepage reads event data from `_data/events.json`.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/ical/`.
 - `MEETUP_EVENTS_URL` (optional): override Meetup events page URL used as the JSON-LD fallback source.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/`.
+- `MEETUP_PAST_EVENTS_URL` (optional): override Meetup past-events page URL used to supplement iCal with recent historical events.
+  - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/past/`.
 - `MEETUP_SYNC_STRICT` (optional): if truthy (`1`, `true`, `yes`, `on`), the script exits non-zero when fetch fails.
   - Useful in CI to surface data-source outages immediately.
+- `MEETUP_SYNC_DEBUG` (optional): if truthy, emits detailed fetch/parse diagnostics to stdout (source URLs, payload sizes, parsed counts, and sample event URLs).
 
 By default, the GitHub Actions workflow uses the script defaults for source URLs (no secrets required).
 

--- a/scripts/sync_meetup_events.py
+++ b/scripts/sync_meetup_events.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+from urllib.parse import urljoin
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -17,10 +18,16 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_FILE = REPO_ROOT / "_data" / "events.json"
 DEFAULT_ICAL_URL = "https://www.meetup.com/genai-gurus/events/ical/"
 DEFAULT_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/"
+DEFAULT_PAST_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/past/"
 
 
 def log(msg: str) -> None:
     print(f"[sync-meetup-events] {msg}")
+
+
+def debug(msg: str) -> None:
+    if os.environ.get("MEETUP_SYNC_DEBUG", "").strip().lower() in {"1", "true", "yes", "on"}:
+        print(f"[sync-meetup-events][debug] {msg}")
 
 
 def unfold_ical_lines(text: str) -> list[str]:
@@ -53,6 +60,16 @@ def strip_html(value: str) -> str:
     no_tags = re.sub(r"<[^>]+>", " ", value)
     normalized = re.sub(r"\s+", " ", no_tags)
     return html.unescape(normalized).strip()
+
+
+def unescape_ical_text(value: str) -> str:
+    return (
+        value.replace("\\n", "\n")
+        .replace("\\N", "\n")
+        .replace("\\,", ",")
+        .replace("\\;", ";")
+        .replace("\\\\", "\\")
+    )
 
 
 def extract_speaker(summary: str, description: str) -> str:
@@ -94,9 +111,9 @@ def parse_ical_events(ical_text: str) -> list[dict[str, str]]:
         if event_dt is None:
             continue
 
-        summary = strip_html(item.get("SUMMARY", "")).strip()
-        description = strip_html(item.get("DESCRIPTION", "")).strip()
-        location = strip_html(item.get("LOCATION", "")).strip()
+        summary = strip_html(unescape_ical_text(item.get("SUMMARY", ""))).strip()
+        description = strip_html(unescape_ical_text(item.get("DESCRIPTION", ""))).strip()
+        location = strip_html(unescape_ical_text(item.get("LOCATION", ""))).strip()
         meetup_url = item.get("URL", "").strip() or DEFAULT_ICAL_URL
         speaker = extract_speaker(summary, description)
 
@@ -115,6 +132,7 @@ def parse_ical_events(ical_text: str) -> list[dict[str, str]]:
         )
 
     parsed_events.sort(key=lambda e: e["date"])
+    debug(f"parse_ical_events: parsed {len(parsed_events)} events")
     return parsed_events
 
 
@@ -150,9 +168,15 @@ def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
             continue
 
         nodes = payload if isinstance(payload, list) else [payload]
+        expanded_nodes: list[dict[str, object]] = []
         for node in nodes:
             if not isinstance(node, dict):
                 continue
+            if isinstance(node.get("@graph"), list):
+                expanded_nodes.extend([g for g in node["@graph"] if isinstance(g, dict)])
+            expanded_nodes.append(node)
+
+        for node in expanded_nodes:
             node_type = node.get("@type")
             if isinstance(node_type, list):
                 is_event = "Event" in node_type
@@ -199,35 +223,99 @@ def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
         key = event.get("meetup_url") or f"{event.get('title')}|{event.get('date')}"
         deduped[key] = event
     ordered = sorted(deduped.values(), key=lambda e: e["date"])
+    debug(f"parse_ld_json_events: parsed {len(ordered)} events")
     return ordered
+
+
+def merge_events(*event_lists: list[dict[str, str]]) -> list[dict[str, str]]:
+    merged: dict[str, dict[str, str]] = {}
+    for events in event_lists:
+        for event in events:
+            key = event.get("meetup_url") or f"{event.get('title')}|{event.get('date')}"
+            merged[key] = event
+    return sorted(merged.values(), key=lambda e: e["date"])
+
+
+def extract_event_urls_from_html(page_html: str) -> list[str]:
+    pattern = re.compile(
+        r'href=["\'](?P<href>(?:https?://www\.meetup\.com)?/[^"\']+/events/[^"\']+)["\']',
+        flags=re.IGNORECASE,
+    )
+    seen: set[str] = set()
+    urls: list[str] = []
+    for match in pattern.finditer(page_html):
+        candidate = match.group("href")
+        normalized = urljoin("https://www.meetup.com", candidate).split("?", 1)[0].rstrip("/")
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        urls.append(normalized)
+    debug(f"extract_event_urls_from_html: found {len(urls)} candidate event URLs")
+    return urls
+
+
+def fetch_url(url: str, headers: dict[str, str], timeout: int = 25) -> str:
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"Meetup fetch failed for {url} with status {response.status}")
+        payload = response.read().decode("utf-8", errors="replace")
+        debug(f"fetch_url: {url} -> status {response.status}, bytes={len(payload)}")
+        return payload
 
 
 def fetch_events() -> list[dict[str, str]]:
     source_url = getenv_or_default("MEETUP_ICAL_URL", DEFAULT_ICAL_URL)
     events_url = getenv_or_default("MEETUP_EVENTS_URL", DEFAULT_EVENTS_URL)
+    past_events_url = getenv_or_default("MEETUP_PAST_EVENTS_URL", DEFAULT_PAST_EVENTS_URL)
     headers = {"User-Agent": "genai-gurus-event-sync/1.0"}
+    debug(f"fetch_events: source_url={source_url}")
+    debug(f"fetch_events: events_url={events_url}")
+    debug(f"fetch_events: past_events_url={past_events_url}")
 
     errors: list[str] = []
 
+    ical_events: list[dict[str, str]] = []
+    past_events: list[dict[str, str]] = []
+
     try:
-        req = urllib.request.Request(source_url, headers=headers)
-        with urllib.request.urlopen(req, timeout=25) as response:
-            if response.status != 200:
-                raise RuntimeError(f"Meetup iCal fetch failed with status {response.status}")
-            payload = response.read().decode("utf-8", errors="replace")
-        events = parse_ical_events(payload)
-        if events:
-            return events
-        errors.append("Meetup iCal response contained no events")
+        payload = fetch_url(source_url, headers=headers)
+        ical_events = parse_ical_events(payload)
+        if ical_events:
+            log(f"Fetched {len(ical_events)} events from iCal")
+            debug(f"iCal sample URLs: {[e.get('meetup_url') for e in ical_events[:3]]}")
+        else:
+            errors.append("Meetup iCal response contained no events")
     except (urllib.error.URLError, RuntimeError, ValueError) as exc:
         errors.append(f"iCal source failed: {exc}")
 
     try:
-        req = urllib.request.Request(events_url, headers=headers)
-        with urllib.request.urlopen(req, timeout=25) as response:
-            if response.status != 200:
-                raise RuntimeError(f"Meetup events page fetch failed with status {response.status}")
-            payload = response.read().decode("utf-8", errors="replace")
+        payload = fetch_url(past_events_url, headers=headers)
+        past_events = [event for event in parse_ld_json_events(payload) if event.get("event_status") == "past"]
+        if not past_events:
+            for event_url in extract_event_urls_from_html(payload)[:12]:
+                event_html = fetch_url(event_url, headers=headers, timeout=20)
+                detailed = parse_ld_json_events(event_html)
+                past_events.extend([event for event in detailed if event.get("event_status") == "past"])
+            debug(f"past-event detail crawl produced {len(past_events)} past events before merge")
+        if past_events:
+            log(f"Fetched {len(past_events)} past events from events/past page")
+            debug(f"Past sample URLs: {[e.get('meetup_url') for e in past_events[:5]]}")
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        errors.append(f"past events source failed: {exc}")
+
+    merged_events = merge_events(ical_events, past_events)
+    debug(
+        "Merged counts: "
+        f"ical={len(ical_events)}, past={len(past_events)}, merged={len(merged_events)}, "
+        f"upcoming={sum(1 for e in merged_events if e.get('event_status') == 'upcoming')}, "
+        f"past={sum(1 for e in merged_events if e.get('event_status') == 'past')}"
+    )
+    if merged_events:
+        return merged_events
+
+    try:
+        payload = fetch_url(events_url, headers=headers)
         events = parse_ld_json_events(payload)
         if events:
             return events
@@ -263,6 +351,7 @@ def getenv_or_default(name: str, default: str) -> str:
 
 
 def main() -> int:
+    debug("Debug logging enabled via MEETUP_SYNC_DEBUG")
     try:
         events = fetch_events()
     except (urllib.error.URLError, RuntimeError, ValueError) as exc:

--- a/tests/test_sync_meetup_events.py
+++ b/tests/test_sync_meetup_events.py
@@ -1,0 +1,49 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "sync_meetup_events.py"
+spec = importlib.util.spec_from_file_location("sync_meetup_events", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(mod)
+
+
+class SyncMeetupEventsTests(unittest.TestCase):
+    def test_extract_event_urls_handles_relative_and_absolute_links(self):
+        html = '''
+        <a href="/genai-gurus/events/312645423/">Past A</a>
+        <a href="https://www.meetup.com/genai-gurus/events/313946334/?foo=bar">Past B</a>
+        <a href="/genai-gurus/about/">About</a>
+        '''
+        urls = mod.extract_event_urls_from_html(html)
+        self.assertIn("https://www.meetup.com/genai-gurus/events/312645423", urls)
+        self.assertIn("https://www.meetup.com/genai-gurus/events/313946334", urls)
+        self.assertEqual(len(urls), 2)
+
+    def test_parse_ld_json_events_supports_graph_nodes(self):
+        html = '''
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "Event",
+              "name": "Past Meetup Event",
+              "startDate": "2025-10-20T18:30:00+02:00",
+              "url": "https://www.meetup.com/genai-gurus/events/312645423/",
+              "location": {"name": "Online"},
+              "description": "Speaker: Jane Doe"
+            }
+          ]
+        }
+        </script>
+        '''
+        events = mod.parse_ld_json_events(html)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["title"], "Past Meetup Event")
+        self.assertEqual(events[0]["event_status"], "past")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve event coverage by harvesting recent historical events from Meetup in addition to the iCal feed so the site can show recent past meetups.  
- Make the sync behavior more observable and debuggable in CI by emitting diagnostics and exposing a debug flag.  
- Allow validation on pull requests and avoid committing from non-push/schedule/manual contexts to reduce unexpected pushes.

### Description
- Expanded GitHub Actions workflow to trigger on `pull_request`, set `MEETUP_SYNC_DEBUG` by default in the job, and only run the commit step for `push`, `schedule`, or `workflow_dispatch` events, and enhance the run-time stats output to show the most recent past event and URL.  
- Updated `README.md` to document `MEETUP_PAST_EVENTS_URL` and `MEETUP_SYNC_DEBUG` and to reflect the new workflow triggers and behavior.  
- Enhanced `scripts/sync_meetup_events.py` with debug logging, unescaping of iCal text, better JSON-LD parsing (including `@graph` nodes), utilities to extract event URLs from meetup HTML, a `fetch_url` wrapper, merging of iCal and past-event lists, and a crawl of the `events/past` page (and individual event pages) to supplement parsed past events.  
- Added unit tests in `tests/test_sync_meetup_events.py` covering `extract_event_urls_from_html` and JSON-LD `@graph` parsing.

### Testing
- Ran the new unit tests with `python -m unittest tests.test_sync_meetup_events` and the two included tests passed.  
- Manual linting and basic smoke-run of `scripts/sync_meetup_events.py` were exercised during development to verify parsing branches (no automated failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00cf23d248324b27b8d29fdbb43cb)