### PR TITLE
Meetup sync: add past-event discovery, link caching, debug logging, and workflow updates

### DIFF
--- a/.github/workflows/sync-meetup-events.yml
+++ b/.github/workflows/sync-meetup-events.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
       - master
-    paths:
-      - '.github/workflows/sync-meetup-events.yml'
-      - 'scripts/sync_meetup_events.py'
-      - '_data/events.json'
+  pull_request:
+    branches:
+      - main
+      - master
   schedule:
     - cron: '15 */12 * * *'
   workflow_dispatch:
@@ -33,6 +33,7 @@ jobs:
         run: python scripts/sync_meetup_events.py
         env:
           MEETUP_SYNC_STRICT: '1'
+          MEETUP_SYNC_DEBUG: '1'
 
       - name: Show synced event stats
         run: |
@@ -51,16 +52,24 @@ jobs:
             print("Next upcoming:")
             next_event = sorted(upcoming, key=lambda e: e.get("date", ""))[0]
             print(f"- {next_event.get('date')} | {next_event.get('title')}")
+          if past:
+            print("Most recent past:")
+            most_recent_past = sorted(past, key=lambda e: e.get("date", ""), reverse=True)[0]
+            print(f"- {most_recent_past.get('date')} | {most_recent_past.get('title')}")
+            print(f"- URL: {most_recent_past.get('meetup_url')}")
+          else:
+            print("Most recent past: <none>")
           PY
 
       - name: Commit changes when event data changed
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          if git diff --quiet -- _data/events.json; then
+          if git diff --quiet -- _data/events.json _data/event_links.json; then
             echo "No changes to commit"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add _data/events.json
+          git add _data/events.json _data/event_links.json
           git commit -m "chore: sync Meetup events"
           git push

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ bundle exec jekyll serve
 ## Event data and maintenance
 
 The homepage reads event data from `_data/events.json`.
+Discovered Meetup event URLs are persisted in `_data/event_links.json`.
 
-- **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours and on manual dispatch.
-  - It also runs on pushes to `main`/`master` that touch the workflow, sync script, or `_data/events.json` so first-time setup is easier to verify.
+- **Automated sync:** `.github/workflows/sync-meetup-events.yml` runs every 12 hours, on manual dispatch, on pull requests targeting `main`/`master`, and on all pushes to `main`/`master`.
 - **Sync script:** `scripts/sync_meetup_events.py` fetches Meetup data and writes deterministic JSON output.
   - Primary source: Meetup iCal feed.
   - Fallback source: JSON-LD event data from the Meetup events page.
 - **Commit behavior:** The workflow only commits when `_data/events.json` actually changes.
+  - It also commits when `_data/event_links.json` changes (new discovered event URLs).
 - **Failure behavior:** If Meetup fetch fails, the script logs a warning and keeps the last successful local data file.
   - In GitHub Actions, strict mode is enabled so fetch failures fail the workflow run (instead of silently succeeding).
+  - If fresh fetches contain no past events (e.g., source requires login), cached past events already in `_data/events.json` are preserved.
 
 ### Optional source overrides
 
@@ -28,8 +30,13 @@ The homepage reads event data from `_data/events.json`.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/ical/`.
 - `MEETUP_EVENTS_URL` (optional): override Meetup events page URL used as the JSON-LD fallback source.
   - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/`.
+- `MEETUP_PAST_EVENTS_URL` (optional): override Meetup past-events page URL used to supplement iCal with recent historical events.
+  - If not set, the script defaults to `https://www.meetup.com/genai-gurus/events/past/`.
+- `MEETUP_EVENTS_API_URL` (optional): override Meetup REST events endpoint used as an additional fallback for past events.
+  - If not set, the script defaults to `https://api.meetup.com/genai-gurus/events`.
 - `MEETUP_SYNC_STRICT` (optional): if truthy (`1`, `true`, `yes`, `on`), the script exits non-zero when fetch fails.
   - Useful in CI to surface data-source outages immediately.
+- `MEETUP_SYNC_DEBUG` (optional): if truthy, emits detailed fetch/parse diagnostics to stdout (source URLs, payload sizes, parsed counts, and sample event URLs).
 
 By default, the GitHub Actions workflow uses the script defaults for source URLs (no secrets required).
 

--- a/_data/event_links.json
+++ b/_data/event_links.json
@@ -1,0 +1,3 @@
+[
+  "https://www.meetup.com/genai-gurus/events/313946334"
+]

--- a/scripts/sync_meetup_events.py
+++ b/scripts/sync_meetup_events.py
@@ -9,18 +9,27 @@ import json
 import os
 import re
 import sys
+from urllib.parse import urlencode, urljoin
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_FILE = REPO_ROOT / "_data" / "events.json"
+EVENT_LINKS_FILE = REPO_ROOT / "_data" / "event_links.json"
 DEFAULT_ICAL_URL = "https://www.meetup.com/genai-gurus/events/ical/"
 DEFAULT_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/"
+DEFAULT_PAST_EVENTS_URL = "https://www.meetup.com/genai-gurus/events/past/"
+DEFAULT_EVENTS_API_URL = "https://api.meetup.com/genai-gurus/events"
 
 
 def log(msg: str) -> None:
     print(f"[sync-meetup-events] {msg}")
+
+
+def debug(msg: str) -> None:
+    if os.environ.get("MEETUP_SYNC_DEBUG", "").strip().lower() in {"1", "true", "yes", "on"}:
+        print(f"[sync-meetup-events][debug] {msg}")
 
 
 def unfold_ical_lines(text: str) -> list[str]:
@@ -53,6 +62,16 @@ def strip_html(value: str) -> str:
     no_tags = re.sub(r"<[^>]+>", " ", value)
     normalized = re.sub(r"\s+", " ", no_tags)
     return html.unescape(normalized).strip()
+
+
+def unescape_ical_text(value: str) -> str:
+    return (
+        value.replace("\\n", "\n")
+        .replace("\\N", "\n")
+        .replace("\\,", ",")
+        .replace("\\;", ";")
+        .replace("\\\\", "\\")
+    )
 
 
 def extract_speaker(summary: str, description: str) -> str:
@@ -94,9 +113,9 @@ def parse_ical_events(ical_text: str) -> list[dict[str, str]]:
         if event_dt is None:
             continue
 
-        summary = strip_html(item.get("SUMMARY", "")).strip()
-        description = strip_html(item.get("DESCRIPTION", "")).strip()
-        location = strip_html(item.get("LOCATION", "")).strip()
+        summary = strip_html(unescape_ical_text(item.get("SUMMARY", ""))).strip()
+        description = strip_html(unescape_ical_text(item.get("DESCRIPTION", ""))).strip()
+        location = strip_html(unescape_ical_text(item.get("LOCATION", ""))).strip()
         meetup_url = item.get("URL", "").strip() or DEFAULT_ICAL_URL
         speaker = extract_speaker(summary, description)
 
@@ -115,6 +134,7 @@ def parse_ical_events(ical_text: str) -> list[dict[str, str]]:
         )
 
     parsed_events.sort(key=lambda e: e["date"])
+    debug(f"parse_ical_events: parsed {len(parsed_events)} events")
     return parsed_events
 
 
@@ -150,9 +170,15 @@ def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
             continue
 
         nodes = payload if isinstance(payload, list) else [payload]
+        expanded_nodes: list[dict[str, object]] = []
         for node in nodes:
             if not isinstance(node, dict):
                 continue
+            if isinstance(node.get("@graph"), list):
+                expanded_nodes.extend([g for g in node["@graph"] if isinstance(g, dict)])
+            expanded_nodes.append(node)
+
+        for node in expanded_nodes:
             node_type = node.get("@type")
             if isinstance(node_type, list):
                 is_event = "Event" in node_type
@@ -199,35 +225,290 @@ def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
         key = event.get("meetup_url") or f"{event.get('title')}|{event.get('date')}"
         deduped[key] = event
     ordered = sorted(deduped.values(), key=lambda e: e["date"])
+    debug(f"parse_ld_json_events: parsed {len(ordered)} events")
     return ordered
+
+
+def merge_events(*event_lists: list[dict[str, str]]) -> list[dict[str, str]]:
+    merged: dict[str, dict[str, str]] = {}
+    for events in event_lists:
+        for event in events:
+            key = event.get("meetup_url") or f"{event.get('title')}|{event.get('date')}"
+            merged[key] = event
+    return sorted(merged.values(), key=lambda e: e["date"])
+
+
+def normalize_event_url(url: str) -> str:
+    return (url or "").strip().split("?", 1)[0].rstrip("/")
+
+
+def load_event_links() -> list[str]:
+    if not EVENT_LINKS_FILE.exists():
+        return []
+    try:
+        payload = json.loads(EVENT_LINKS_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [normalize_event_url(str(item)) for item in payload if normalize_event_url(str(item))]
+
+
+def write_event_links_if_changed(links: list[str]) -> bool:
+    deduped = sorted({normalize_event_url(link) for link in links if normalize_event_url(link)})
+    serialized = json.dumps(deduped, ensure_ascii=False, indent=2) + "\n"
+    EVENT_LINKS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if EVENT_LINKS_FILE.exists() and EVENT_LINKS_FILE.read_text(encoding="utf-8") == serialized:
+        return False
+    EVENT_LINKS_FILE.write_text(serialized, encoding="utf-8")
+    return True
+
+
+def discover_links_from_visible_sources(headers: dict[str, str], source_url: str, events_url: str) -> list[str]:
+    discovered: set[str] = set()
+    try:
+        payload = fetch_url(source_url, headers=headers)
+        for event in parse_ical_events(payload):
+            discovered.add(normalize_event_url(event.get("meetup_url", "")))
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        debug(f"discover_links: iCal source failed: {exc}")
+
+    try:
+        payload = fetch_url(events_url, headers=headers)
+        for event in parse_ld_json_events(payload):
+            discovered.add(normalize_event_url(event.get("meetup_url", "")))
+        for link in extract_event_urls_from_html(payload):
+            discovered.add(normalize_event_url(link))
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        debug(f"discover_links: events page source failed: {exc}")
+
+    links = sorted([link for link in discovered if link])
+    debug(f"discover_links: found {len(links)} links from visible sources")
+    return links
+
+
+def hydrate_events_from_links(
+    links: list[str],
+    headers: dict[str, str],
+    fallback_events_by_url: dict[str, dict[str, str]],
+) -> list[dict[str, str]]:
+    hydrated: list[dict[str, str]] = []
+    for link in links:
+        normalized = normalize_event_url(link)
+        if not normalized:
+            continue
+        parsed_for_link: list[dict[str, str]] = []
+        try:
+            payload = fetch_url(normalized, headers=headers, timeout=20)
+            parsed_for_link = parse_ld_json_events(payload)
+        except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+            debug(f"hydrate_events_from_links: failed to fetch {normalized}: {exc}")
+
+        chosen: dict[str, str] | None = None
+        for item in parsed_for_link:
+            if normalize_event_url(item.get("meetup_url", "")) == normalized:
+                chosen = item
+                break
+        if chosen is None and parsed_for_link:
+            chosen = parsed_for_link[0]
+
+        if chosen is None:
+            chosen = fallback_events_by_url.get(normalized)
+
+        if chosen is not None:
+            hydrated.append(chosen)
+
+    debug(f"hydrate_events_from_links: produced {len(hydrated)} events from {len(links)} links")
+    return hydrated
+
+
+def parse_api_events(events_payload: str) -> list[dict[str, str]]:
+    try:
+        payload = json.loads(events_payload)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(payload, list):
+        return []
+
+    now = dt.datetime.now(dt.timezone.utc)
+    parsed_events: list[dict[str, str]] = []
+    for event in payload:
+        if not isinstance(event, dict):
+            continue
+        event_time_ms = event.get("time")
+        if not isinstance(event_time_ms, (int, float)):
+            continue
+
+        event_dt = dt.datetime.fromtimestamp(event_time_ms / 1000, tz=dt.timezone.utc)
+        venue = event.get("venue")
+        location_name = ""
+        if isinstance(venue, dict):
+            location_name = str(venue.get("name", "")).strip()
+        if not location_name:
+            location_name = "Online" if bool(event.get("is_online")) else "TBD"
+
+        description = strip_html(str(event.get("description", "")))
+        parsed_events.append(
+            {
+                "title": strip_html(str(event.get("name", ""))) or "GenAI Gurus Event",
+                "date": event_dt.isoformat().replace("+00:00", "Z"),
+                "event_status": "upcoming" if event_dt >= now else "past",
+                "speaker_name": extract_speaker("", description),
+                "location_label": location_name,
+                "meetup_url": str(event.get("link", "")).strip() or DEFAULT_EVENTS_URL,
+                "youtube_url": "",
+                "image": "",
+                "summary": description[:280],
+            }
+        )
+
+    ordered = sorted(parsed_events, key=lambda e: e["date"])
+    debug(f"parse_api_events: parsed {len(ordered)} events")
+    return ordered
+
+
+def extract_event_urls_from_html(page_html: str) -> list[str]:
+    href_pattern = re.compile(
+        r'href=["\'](?P<href>(?:https?://www\.meetup\.com)?/[^"\']+/events/[^"\']+)["\']',
+        flags=re.IGNORECASE,
+    )
+    text_pattern = re.compile(
+        r'(?P<href>(?:https?://www\.meetup\.com)?/[^"\'\s<>]+/events/\d+/?(?:\?[^"\'\s<>]*)?)',
+        flags=re.IGNORECASE,
+    )
+    seen: set[str] = set()
+    urls: list[str] = []
+
+    href_matches = 0
+    for match in href_pattern.finditer(page_html):
+        candidate = match.group("href")
+        normalized = urljoin("https://www.meetup.com", candidate).split("?", 1)[0].rstrip("/")
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        urls.append(normalized)
+        href_matches += 1
+
+    json_like_html = page_html.replace("\\/", "/")
+    text_matches = 0
+    for match in text_pattern.finditer(json_like_html):
+        candidate = match.group("href")
+        normalized = urljoin("https://www.meetup.com", candidate).split("?", 1)[0].rstrip("/")
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        urls.append(normalized)
+        text_matches += 1
+
+    debug(
+        "extract_event_urls_from_html: "
+        f"{len(urls)} candidate event URLs "
+        f"(href matches added={href_matches}, text/json matches added={text_matches})"
+    )
+    return urls
+
+
+def fetch_url(url: str, headers: dict[str, str], timeout: int = 25) -> str:
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"Meetup fetch failed for {url} with status {response.status}")
+        payload = response.read().decode("utf-8", errors="replace")
+        debug(f"fetch_url: {url} -> status {response.status}, bytes={len(payload)}")
+        return payload
 
 
 def fetch_events() -> list[dict[str, str]]:
     source_url = getenv_or_default("MEETUP_ICAL_URL", DEFAULT_ICAL_URL)
     events_url = getenv_or_default("MEETUP_EVENTS_URL", DEFAULT_EVENTS_URL)
+    past_events_url = getenv_or_default("MEETUP_PAST_EVENTS_URL", DEFAULT_PAST_EVENTS_URL)
+    events_api_url = getenv_or_default("MEETUP_EVENTS_API_URL", DEFAULT_EVENTS_API_URL)
     headers = {"User-Agent": "genai-gurus-event-sync/1.0"}
+    debug(f"fetch_events: source_url={source_url}")
+    debug(f"fetch_events: events_url={events_url}")
+    debug(f"fetch_events: past_events_url={past_events_url}")
+    debug(f"fetch_events: events_api_url={events_api_url}")
 
     errors: list[str] = []
 
-    try:
-        req = urllib.request.Request(source_url, headers=headers)
-        with urllib.request.urlopen(req, timeout=25) as response:
-            if response.status != 200:
-                raise RuntimeError(f"Meetup iCal fetch failed with status {response.status}")
-            payload = response.read().decode("utf-8", errors="replace")
-        events = parse_ical_events(payload)
-        if events:
-            return events
-        errors.append("Meetup iCal response contained no events")
-    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
-        errors.append(f"iCal source failed: {exc}")
+    ical_events: list[dict[str, str]] = []
+    past_events: list[dict[str, str]] = []
 
     try:
-        req = urllib.request.Request(events_url, headers=headers)
-        with urllib.request.urlopen(req, timeout=25) as response:
-            if response.status != 200:
-                raise RuntimeError(f"Meetup events page fetch failed with status {response.status}")
-            payload = response.read().decode("utf-8", errors="replace")
+        payload = fetch_url(source_url, headers=headers)
+        ical_events = parse_ical_events(payload)
+        if ical_events:
+            log(f"Fetched {len(ical_events)} events from iCal")
+            debug(f"iCal sample URLs: {[e.get('meetup_url') for e in ical_events[:3]]}")
+        else:
+            errors.append("Meetup iCal response contained no events")
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        message = f"iCal source failed: {exc}"
+        errors.append(message)
+        debug(message)
+
+    try:
+        payload = fetch_url(past_events_url, headers=headers)
+        past_events = [event for event in parse_ld_json_events(payload) if event.get("event_status") == "past"]
+        if not past_events:
+            for event_url in extract_event_urls_from_html(payload)[:12]:
+                event_html = fetch_url(event_url, headers=headers, timeout=20)
+                detailed = parse_ld_json_events(event_html)
+                past_events.extend([event for event in detailed if event.get("event_status") == "past"])
+            debug(f"past-event detail crawl produced {len(past_events)} past events before merge")
+        if past_events:
+            log(f"Fetched {len(past_events)} past events from events/past page")
+            debug(f"Past sample URLs: {[e.get('meetup_url') for e in past_events[:5]]}")
+    except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+        message = f"past events source failed: {exc}"
+        errors.append(message)
+        debug(message)
+
+    if not past_events:
+        try:
+            query = urlencode(
+                {
+                    "status": "past",
+                    "page": 20,
+                    "desc": "true",
+                    "only": "name,time,link,description,is_online,venue",
+                }
+            )
+            api_url = f"{events_api_url}?{query}"
+            debug(f"Trying Meetup API fallback URL: {api_url}")
+            api_payload = fetch_url(api_url, headers=headers)
+            api_events = [event for event in parse_api_events(api_payload) if event.get("event_status") == "past"]
+            if api_events:
+                past_events = api_events
+                log(f"Fetched {len(past_events)} past events from Meetup API")
+                debug(f"API past sample URLs: {[e.get('meetup_url') for e in past_events[:5]]}")
+            else:
+                message = "Meetup API returned no parseable past events"
+                errors.append(message)
+                debug(message)
+        except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+            message = f"events API source failed: {exc}"
+            errors.append(message)
+            debug(message)
+
+    merged_events = merge_events(ical_events, past_events)
+    debug(
+        "Merged counts: "
+        f"ical={len(ical_events)}, past={len(past_events)}, merged={len(merged_events)}, "
+        f"upcoming={sum(1 for e in merged_events if e.get('event_status') == 'upcoming')}, "
+        f"past={sum(1 for e in merged_events if e.get('event_status') == 'past')}"
+    )
+    if not past_events:
+        debug("No past events recovered from any source")
+        for source_error in errors:
+            if "past events source failed" in source_error or "events API source failed" in source_error:
+                debug(f"Past-source diagnostic: {source_error}")
+    if merged_events:
+        return merged_events
+
+    try:
+        payload = fetch_url(events_url, headers=headers)
         events = parse_ld_json_events(payload)
         if events:
             return events
@@ -247,6 +528,36 @@ def write_if_changed(events: list[dict[str, str]]) -> bool:
     return True
 
 
+def load_existing_events() -> list[dict[str, str]]:
+    if not OUTPUT_FILE.exists():
+        return []
+    try:
+        payload = json.loads(OUTPUT_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    return [event for event in payload if isinstance(event, dict)]
+
+
+def preserve_existing_past_events(fetched_events: list[dict[str, str]]) -> list[dict[str, str]]:
+    fetched_past_count = sum(1 for event in fetched_events if event.get("event_status") == "past")
+    if fetched_past_count > 0:
+        return fetched_events
+
+    existing_events = load_existing_events()
+    existing_past = [event for event in existing_events if event.get("event_status") == "past"]
+    if not existing_past:
+        return fetched_events
+
+    merged = merge_events(fetched_events, existing_past)
+    log(
+        "No past events fetched from Meetup sources; "
+        f"preserved {len(existing_past)} cached past events from _data/events.json"
+    )
+    return merged
+
+
 def is_truthy_env(name: str, default: bool = False) -> bool:
     raw = os.environ.get(name)
     if raw is None:
@@ -263,6 +574,7 @@ def getenv_or_default(name: str, default: str) -> str:
 
 
 def main() -> int:
+    debug("Debug logging enabled via MEETUP_SYNC_DEBUG")
     try:
         events = fetch_events()
     except (urllib.error.URLError, RuntimeError, ValueError) as exc:
@@ -275,11 +587,31 @@ def main() -> int:
             return 1
         return 0
 
+    existing_events = load_existing_events()
+    headers = {"User-Agent": "genai-gurus-event-sync/1.0"}
+    discovered_links = discover_links_from_visible_sources(headers, DEFAULT_ICAL_URL, DEFAULT_EVENTS_URL)
+    existing_links = load_event_links()
+    cached_links = [normalize_event_url(event.get("meetup_url", "")) for event in existing_events]
+    fetched_links = [normalize_event_url(event.get("meetup_url", "")) for event in events]
+    all_links = sorted({link for link in [*existing_links, *cached_links, *fetched_links, *discovered_links] if link})
+    links_changed = write_event_links_if_changed(all_links)
+
+    fallback_map = {
+        normalize_event_url(event.get("meetup_url", "")): event
+        for event in merge_events(existing_events, events)
+        if normalize_event_url(event.get("meetup_url", ""))
+    }
+    hydrated_events = hydrate_events_from_links(all_links, headers=headers, fallback_events_by_url=fallback_map)
+    events = merge_events(events, hydrated_events)
+    events = preserve_existing_past_events(events)
     changed = write_if_changed(events)
     upcoming_count = sum(1 for event in events if event.get("event_status") == "upcoming")
     past_count = sum(1 for event in events if event.get("event_status") == "past")
     log(f"Synced {len(events)} events ({upcoming_count} upcoming, {past_count} past)")
-    log("Updated _data/events.json" if changed else "No event data changes detected")
+    if changed or links_changed:
+        log("Updated event data files" if changed and links_changed else ("Updated _data/events.json" if changed else "Updated _data/event_links.json"))
+    else:
+        log("No event data changes detected")
     return 0
 
 

--- a/tests/test_sync_meetup_events.py
+++ b/tests/test_sync_meetup_events.py
@@ -1,0 +1,134 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "sync_meetup_events.py"
+spec = importlib.util.spec_from_file_location("sync_meetup_events", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(mod)
+
+
+class SyncMeetupEventsTests(unittest.TestCase):
+    def test_extract_event_urls_handles_relative_and_absolute_links(self):
+        html = '''
+        <a href="/genai-gurus/events/312645423/">Past A</a>
+        <a href="https://www.meetup.com/genai-gurus/events/313946334/?foo=bar">Past B</a>
+        <a href="/genai-gurus/about/">About</a>
+        '''
+        urls = mod.extract_event_urls_from_html(html)
+        self.assertIn("https://www.meetup.com/genai-gurus/events/312645423", urls)
+        self.assertIn("https://www.meetup.com/genai-gurus/events/313946334", urls)
+        self.assertEqual(len(urls), 2)
+
+    def test_parse_ld_json_events_supports_graph_nodes(self):
+        html = '''
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "Event",
+              "name": "Past Meetup Event",
+              "startDate": "2025-10-20T18:30:00+02:00",
+              "url": "https://www.meetup.com/genai-gurus/events/312645423/",
+              "location": {"name": "Online"},
+              "description": "Speaker: Jane Doe"
+            }
+          ]
+        }
+        </script>
+        '''
+        events = mod.parse_ld_json_events(html)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["title"], "Past Meetup Event")
+        self.assertEqual(events[0]["event_status"], "past")
+
+    def test_extract_event_urls_handles_json_escaped_urls(self):
+        html = r'''
+        <script>
+          window.__DATA__ = {"links":["https:\/\/www.meetup.com\/genai-gurus\/events\/312645423\/?eventOrigin=group_past_events"]};
+        </script>
+        '''
+        urls = mod.extract_event_urls_from_html(html)
+        self.assertIn("https://www.meetup.com/genai-gurus/events/312645423", urls)
+
+    def test_parse_api_events_handles_meetup_rest_payload(self):
+        payload = """
+        [
+          {
+            "name": "GenAI Past Session",
+            "time": 1729445400000,
+            "link": "https://www.meetup.com/genai-gurus/events/312645423/",
+            "description": "Speaker: Jane Doe",
+            "is_online": true,
+            "venue": {"name": "Online"}
+          }
+        ]
+        """
+        events = mod.parse_api_events(payload)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["title"], "GenAI Past Session")
+        self.assertEqual(events[0]["meetup_url"], "https://www.meetup.com/genai-gurus/events/312645423/")
+
+    def test_preserve_existing_past_events_when_fetch_returns_only_upcoming(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_output = Path(tmpdir) / "events.json"
+            temp_output.write_text(
+                json.dumps(
+                    [
+                        {
+                            "title": "Past Event",
+                            "date": "2025-10-20T16:30:00Z",
+                            "event_status": "past",
+                            "meetup_url": "https://www.meetup.com/genai-gurus/events/312645423/",
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            original_output = mod.OUTPUT_FILE
+            mod.OUTPUT_FILE = temp_output
+            try:
+                merged = mod.preserve_existing_past_events(
+                    [
+                        {
+                            "title": "Upcoming Event",
+                            "date": "2026-04-15T19:00:00Z",
+                            "event_status": "upcoming",
+                            "meetup_url": "https://www.meetup.com/genai-gurus/events/313946334/",
+                        }
+                    ]
+                )
+            finally:
+                mod.OUTPUT_FILE = original_output
+
+        self.assertEqual(len(merged), 2)
+        statuses = {event["event_status"] for event in merged}
+        self.assertIn("past", statuses)
+        self.assertIn("upcoming", statuses)
+
+    def test_event_links_file_roundtrip_and_normalization(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_links = Path(tmpdir) / "event_links.json"
+            original_links_file = mod.EVENT_LINKS_FILE
+            mod.EVENT_LINKS_FILE = temp_links
+            try:
+                changed = mod.write_event_links_if_changed(
+                    [
+                        "https://www.meetup.com/genai-gurus/events/313946334/?foo=1",
+                        "https://www.meetup.com/genai-gurus/events/313946334/",
+                    ]
+                )
+                links = mod.load_event_links()
+            finally:
+                mod.EVENT_LINKS_FILE = original_links_file
+
+        self.assertTrue(changed)
+        self.assertEqual(links, ["https://www.meetup.com/genai-gurus/events/313946334"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve robustness of Meetup sync by recovering recent past events from multiple sources when iCal/visible JSON-LD are insufficient. 
- Persist discovered event URLs so the sync can hydrate event details even when primary feeds omit past items. 
- Make the Actions workflow run more broadly (PRs and all pushes to main/master) and add optional debug diagnostics.

### Description
- Expanded `.github/workflows/sync-meetup-events.yml` to trigger on `pull_request` and on all pushes to `main`/`master`, added `MEETUP_SYNC_DEBUG` env, enhanced stats output, and changed commit logic to include `_data/event_links.json` and only commit on `push`, `schedule`, or `workflow_dispatch` runs via a conditional.
- Implemented many enhancements in `scripts/sync_meetup_events.py`: added debug logging, `unescape_ical_text`, better JSON-LD handling (including `@graph`), iCal unescaping, HTML event-URL extraction, Meetup API fallback parsing, merging/deduping of event lists, URL normalization, link discovery/hydration, and preservation of cached past events when no past events are fetched.
- Added persistent `_data/event_links.json` initial content and read/write helpers so discovered event URLs are stored and used for later hydration.
- Updated `README.md` to document the new `event_links` file, new env overrides (`MEETUP_PAST_EVENTS_URL`, `MEETUP_EVENTS_API_URL`, `MEETUP_SYNC_DEBUG`), and clarified workflow triggers and commit behavior.
- Added unit tests in `tests/test_sync_meetup_events.py` exercising URL extraction, JSON-LD `@graph` parsing, API payload parsing, past-event preservation behavior, and event-links normalization/roundtrip.

### Testing
- Added `tests/test_sync_meetup_events.py` and ran the test suite with `python -m unittest tests/test_sync_meetup_events.py`, and all tests passed.
- Verified the workflow script changes by inspecting the job steps and local runs of `scripts/sync_meetup_events.py` with `MEETUP_SYNC_DEBUG=1` to confirm debug output and file write behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00cf23d248324b27b8d29fdbb43cb)