### PR TITLE
Sync Meetup event images from event page card artwork

### DIFF
--- a/scripts/sync_meetup_events.py
+++ b/scripts/sync_meetup_events.py
@@ -228,6 +228,72 @@ def parse_ld_json_events(events_html: str) -> list[dict[str, str]]:
     return ordered
 
 
+def extract_image_from_event_html(event_html: str) -> str:
+    og_image_pattern = re.compile(
+        r'<meta[^>]+property=["\']og:image["\'][^>]+content=["\']([^"\']+)["\']',
+        flags=re.IGNORECASE,
+    )
+    og_match = og_image_pattern.search(event_html)
+    if og_match:
+        return html.unescape(og_match.group(1)).strip()
+
+    script_pattern = re.compile(
+        r'<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    for match in script_pattern.findall(event_html):
+        candidate = match.strip()
+        if not candidate:
+            continue
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+
+        nodes = payload if isinstance(payload, list) else [payload]
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            image = node.get("image")
+            if isinstance(image, str) and image.strip():
+                return image.strip()
+            if isinstance(image, list):
+                for value in image:
+                    if isinstance(value, str) and value.strip():
+                        return value.strip()
+    return ""
+
+
+def fill_event_images(events: list[dict[str, str]], headers: dict[str, str]) -> list[dict[str, str]]:
+    updated_events: list[dict[str, str]] = []
+    image_cache: dict[str, str] = {}
+    for event in events:
+        normalized_event = dict(event)
+        meetup_url = str(normalized_event.get("meetup_url", "")).strip()
+        existing_image = str(normalized_event.get("image", "")).strip()
+        if existing_image or not meetup_url:
+            updated_events.append(normalized_event)
+            continue
+
+        if meetup_url in image_cache:
+            normalized_event["image"] = image_cache[meetup_url]
+            updated_events.append(normalized_event)
+            continue
+
+        try:
+            event_html = fetch_url(meetup_url, headers=headers, timeout=20)
+            image_url = extract_image_from_event_html(event_html)
+        except (urllib.error.URLError, RuntimeError, ValueError) as exc:
+            debug(f"fill_event_images: failed to fetch {meetup_url}: {exc}")
+            image_url = ""
+
+        image_cache[meetup_url] = image_url
+        normalized_event["image"] = image_url
+        updated_events.append(normalized_event)
+
+    return updated_events
+
+
 def merge_events(*event_lists: list[dict[str, str]]) -> list[dict[str, str]]:
     merged: dict[str, dict[str, str]] = {}
     for events in event_lists:
@@ -408,6 +474,7 @@ def fetch_events() -> list[dict[str, str]]:
             debug(message)
 
     merged_events = merge_events(ical_events, past_events)
+    merged_events = fill_event_images(merged_events, headers=headers)
     debug(
         "Merged counts: "
         f"ical={len(ical_events)}, past={len(past_events)}, merged={len(merged_events)}, "

--- a/tests/test_sync_meetup_events.py
+++ b/tests/test_sync_meetup_events.py
@@ -10,6 +10,16 @@ spec.loader.exec_module(mod)
 
 
 class SyncMeetupEventsTests(unittest.TestCase):
+    def test_extract_image_from_event_html_prefers_og_image(self):
+        html = """
+        <meta property="og:image" content="https://images.meetupstatic.com/event.jpg" />
+        <script type="application/ld+json">
+          {"@type":"Event","image":"https://images.meetupstatic.com/other.jpg"}
+        </script>
+        """
+        image_url = mod.extract_image_from_event_html(html)
+        self.assertEqual(image_url, "https://images.meetupstatic.com/event.jpg")
+
     def test_extract_event_urls_handles_relative_and_absolute_links(self):
         html = '''
         <a href="/genai-gurus/events/312645423/">Past A</a>
@@ -70,6 +80,32 @@ class SyncMeetupEventsTests(unittest.TestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0]["title"], "GenAI Past Session")
         self.assertEqual(events[0]["meetup_url"], "https://www.meetup.com/genai-gurus/events/312645423/")
+
+    def test_fill_event_images_uses_event_page_image(self):
+        events = [
+            {
+                "title": "OpenClaw",
+                "date": "2026-04-15T19:00:00Z",
+                "event_status": "upcoming",
+                "speaker_name": "",
+                "location_label": "Online",
+                "meetup_url": "https://www.meetup.com/genai-gurus/events/313946334/",
+                "youtube_url": "",
+                "image": "",
+                "summary": "",
+            }
+        ]
+
+        original_fetch_url = mod.fetch_url
+        try:
+            mod.fetch_url = lambda *_args, **_kwargs: (
+                '<meta property="og:image" content="https://images.meetupstatic.com/correct-image.jpg" />'
+            )
+            updated = mod.fill_event_images(events, headers={})
+        finally:
+            mod.fetch_url = original_fetch_url
+
+        self.assertEqual(updated[0]["image"], "https://images.meetupstatic.com/correct-image.jpg")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- The event card image shown on the site was missing or incorrect because the meetup sync pipeline did not populate event `image` values from the Meetup event page artwork (the top-right card image). 
- The change ensures event listings display the same image used on the Meetup event page for better visual consistency.

### Description

- Added `extract_image_from_event_html(event_html)` which first extracts `og:image` meta tags and falls back to `image` fields found in JSON-LD on the event page.
- Added `fill_event_images(events, headers)` which fetches each event's `meetup_url`, extracts the image, caches per-URL results, and populates missing `image` fields with graceful error handling.
- Integrated image enrichment into the fetch pipeline by calling `fill_event_images(...)` after merging iCal and past events so merged events can be enriched before writing to `_data/events.json`.
- Added unit tests for `extract_image_from_event_html` and `fill_event_images` and updated existing test harness to exercise the new behavior.

### Testing

- Ran unit tests with `python -m unittest tests/test_sync_meetup_events.py` and all tests passed (6 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d046844428832491222af1be4a9cdf)